### PR TITLE
fixed attachment version formatting

### DIFF
--- a/main/migrate-confluence-to-gollum.go
+++ b/main/migrate-confluence-to-gollum.go
@@ -274,7 +274,7 @@ func main() {
 				if attachment.Title == string(match[1]) {
 					html = bytes.Replace(html, match[0], []byte(`<img src="` + w.Path + attachment.Title + `" alt="`+ attachment.Title +`">`), -1)
 					// Copy attachment file
-					attFile := exportDir + "attachments/" + page.Id + "/" + attachment.Id + "/" + string(attachment.Version)
+					attFile := exportDir + "attachments/" + page.Id + "/" + attachment.Id + "/" + strconv.Itoa(attachment.Version)
 					outFile := outputDir + w.Path + w.Filename + "/" + attachment.Title
 					err = copyFileContents(attFile, outFile)
 					if err != nil {


### PR DESCRIPTION
Attachment source version was converted to ascii constrol numbers instead of "1", "2" and so on. This commit fixes this.